### PR TITLE
Enable module builders pick the script automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "toasts"
   ],
   "license": "ISC",
-  "main": "index.js",
+  "main": "dist/js/bootstrap-toasts-js.js",
   "name": "bootstrap-toasts-js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will allow webpack to pick the package directly 